### PR TITLE
Add withFetch to HttpClient configuration

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -4,7 +4,7 @@ import {
   provideZonelessChangeDetection,
 } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withFetch } from '@angular/common/http';
 
 import { routes } from './app.routes';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -15,6 +15,6 @@ export const appConfig: ApplicationConfig = {
     provideZonelessChangeDetection(),
     provideRouter(routes),
     provideClientHydration(withEventReplay()),
-    provideHttpClient(),
+    provideHttpClient(withFetch()),
   ],
 };


### PR DESCRIPTION
## Changes Made

This pull request updates the Angular HTTP client configuration in `src/app/app.config.ts`.

### Modified Files
- `src/app/app.config.ts`

### Changes
- Added `withFetch` import from `@angular/common/http`
- Updated `provideHttpClient()` call to include `withFetch()` parameter

### Technical Details
The HTTP client provider configuration has been changed from:
```typescript
provideHttpClient()
```

To:
```typescript
provideHttpClient(withFetch())
```

This enables the fetch API for HTTP requests in the Angular application.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/da8f1077a1a046a486f8ff53e0c07c0b/mystic-landing)

👀 [Preview Link](https://da8f1077a1a046a486f8ff53e0c07c0b-mystic-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>da8f1077a1a046a486f8ff53e0c07c0b</projectId>-->
<!--<branchName>mystic-landing</branchName>-->