### PR TITLE
Fix ad/:id route prerendering error by switching to server mode

### DIFF
--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -3,10 +3,10 @@ import { RenderMode, ServerRoute } from '@angular/ssr';
 export const serverRoutes: ServerRoute[] = [
   {
     path: 'ad/:id',
-    renderMode: RenderMode.Server
+    renderMode: RenderMode.Server,
   },
   {
     path: '**',
-    renderMode: RenderMode.Prerender
-  }
+    renderMode: RenderMode.Prerender,
+  },
 ];

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -2,6 +2,10 @@ import { RenderMode, ServerRoute } from '@angular/ssr';
 
 export const serverRoutes: ServerRoute[] = [
   {
+    path: 'ad/:id',
+    renderMode: RenderMode.Server
+  },
+  {
     path: '**',
     renderMode: RenderMode.Prerender
   }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -3,6 +3,7 @@ import { RouterOutlet, RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-root',
+  standalone: true,
   imports: [RouterOutlet, RouterLink],
   templateUrl: './app.html',
   styleUrl: './app.css'

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -6,7 +6,7 @@ import { RouterOutlet, RouterLink } from '@angular/router';
   standalone: true,
   imports: [RouterOutlet, RouterLink],
   templateUrl: './app.html',
-  styleUrl: './app.css'
+  styleUrl: './app.css',
 })
 export class App {
   protected readonly title = signal('asanZindegi');


### PR DESCRIPTION
## Purpose
The user encountered a prerendering error for the 'ad/:id' route that includes parameters but was missing the required 'getPrerenderParams' function. The goal was to resolve this Angular SSR configuration issue to allow the parameterized route to work properly.

## Code changes
- **Server routing configuration**: Added specific route configuration for 'ad/:id' path with `RenderMode.Server` instead of prerendering to avoid the missing `getPrerenderParams` requirement
- **Component updates**: Made the App component standalone and added trailing comma for consistency
- **Route precedence**: Positioned the specific 'ad/:id' route before the catch-all '**' route to ensure proper matchingTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/61c4e3cbf6de4ffca27c5a0471b6ff6e/vortex-space)

👀 [Preview Link](https://61c4e3cbf6de4ffca27c5a0471b6ff6e-vortex-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>61c4e3cbf6de4ffca27c5a0471b6ff6e</projectId>-->
<!--<branchName>vortex-space</branchName>-->