### PR TITLE
Add server-side rendering for root path route

### DIFF
--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -2,6 +2,10 @@ import { RenderMode, ServerRoute } from '@angular/ssr';
 
 export const serverRoutes: ServerRoute[] = [
   {
+    path: '',
+    renderMode: RenderMode.Server,
+  },
+  {
     path: 'ad/:id',
     renderMode: RenderMode.Server,
   },


### PR DESCRIPTION
## Changes Made

Added a new server route configuration for the root path (`''`) in the Angular SSR setup.

### Details

- **File Modified**: `src/app/app.routes.server.ts`
- **Change**: Added a new `ServerRoute` object with:
  - `path: ''` (root/empty path)
  - `renderMode: RenderMode.Server`

This addition enables server-side rendering for the application's root route, positioned before the existing `/ad/:id` route configuration.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 11`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3aa5a46aca6d43fca1d7cf200c7895f6/vortex-world)

👀 [Preview Link](https://3aa5a46aca6d43fca1d7cf200c7895f6-vortex-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3aa5a46aca6d43fca1d7cf200c7895f6</projectId>-->
<!--<branchName>vortex-world</branchName>-->