### PR TITLE
Fix ad/:id/edit route rendering mode configuration

### DIFF
--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -6,6 +6,10 @@ export const serverRoutes: ServerRoute[] = [
     renderMode: RenderMode.Server,
   },
   {
+    path: 'ad/:id/edit',
+    renderMode: RenderMode.Server,
+  },
+  {
     path: '**',
     renderMode: RenderMode.Prerender,
   },

--- a/src/app/pages/provider/register/provider-register.component.ts
+++ b/src/app/pages/provider/register/provider-register.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Router, RouterLink } from '@angular/router';
+import { Router } from '@angular/router';
 import { AccountService } from '../../../services/account.service';
 
 @Component({

--- a/src/app/pages/provider/register/provider-register.component.ts
+++ b/src/app/pages/provider/register/provider-register.component.ts
@@ -7,7 +7,7 @@ import { AccountService } from '../../../services/account.service';
 @Component({
   selector: 'app-provider-register',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterLink],
+  imports: [CommonModule, FormsModule],
   templateUrl: './provider-register.component.html',
   styleUrl: './provider-register.component.css',
 })


### PR DESCRIPTION
## Purpose
The user encountered an error where the 'ad/:id/edit' route was using prerendering with parameters but lacked the required 'getPrerenderParams' function. The goal was to resolve this routing configuration issue by specifying an appropriate render mode for the route.

## Code changes
- **Server routes configuration**: Added explicit server-side rendering configuration for the 'ad/:id/edit' route by setting `renderMode: RenderMode.Server`
- **Component cleanup**: Removed unused `RouterLink` import from the provider register componentTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 21`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3aa5a46aca6d43fca1d7cf200c7895f6/pulse-den)

👀 [Preview Link](https://3aa5a46aca6d43fca1d7cf200c7895f6-pulse-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3aa5a46aca6d43fca1d7cf200c7895f6</projectId>-->
<!--<branchName>pulse-den</branchName>-->