### PR TITLE
Add signup form validation and HttpClient fetch config

### DIFF
--- a/src/app/app.config.server.ts
+++ b/src/app/app.config.server.ts
@@ -2,10 +2,12 @@ import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
 import { provideServerRendering, withRoutes } from '@angular/ssr';
 import { appConfig } from './app.config';
 import { serverRoutes } from './app.routes.server';
+import { provideHttpClient, withFetch } from '@angular/common/http';
 
 const serverConfig: ApplicationConfig = {
   providers: [
-    provideServerRendering(withRoutes(serverRoutes))
+    provideServerRendering(withRoutes(serverRoutes)),
+    provideHttpClient(withFetch()),
   ]
 };
 

--- a/src/app/app.config.server.ts
+++ b/src/app/app.config.server.ts
@@ -5,10 +5,7 @@ import { serverRoutes } from './app.routes.server';
 import { provideHttpClient, withFetch } from '@angular/common/http';
 
 const serverConfig: ApplicationConfig = {
-  providers: [
-    provideServerRendering(withRoutes(serverRoutes)),
-    provideHttpClient(withFetch()),
-  ]
+  providers: [provideServerRendering(withRoutes(serverRoutes)), provideHttpClient(withFetch())],
 };
 
 export const config = mergeApplicationConfig(appConfig, serverConfig);

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -4,7 +4,7 @@ import {
   provideZonelessChangeDetection,
 } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withFetch } from '@angular/common/http';
 
 import { routes } from './app.routes';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
@@ -15,6 +15,6 @@ export const appConfig: ApplicationConfig = {
     provideZonelessChangeDetection(),
     provideRouter(routes),
     provideClientHydration(withEventReplay()),
-    provideHttpClient(),
+    provideHttpClient(withFetch()),
   ],
 };

--- a/src/app/pages/auth/reset-password/reset-password.component.ts
+++ b/src/app/pages/auth/reset-password/reset-password.component.ts
@@ -1,13 +1,13 @@
 import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Router, RouterLink } from '@angular/router';
+import { Router } from '@angular/router';
 import { ApiService } from '../../../services/api.service';
 
 @Component({
   selector: 'app-reset-password',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterLink],
+  imports: [CommonModule, FormsModule],
   templateUrl: './reset-password.component.html',
   styleUrl: './reset-password.component.css',
 })

--- a/src/app/pages/auth/signup/signup.component.html
+++ b/src/app/pages/auth/signup/signup.component.html
@@ -86,7 +86,11 @@
                 </div>
               </div>
 
-              <button class="btn btn-join btn-lg w-100" type="submit" [disabled]="f.invalid || submitting">
+              <button
+                class="btn btn-join btn-lg w-100"
+                type="submit"
+                [disabled]="f.invalid || submitting"
+              >
                 {{ submitting ? 'Signing up...' : 'Sign up' }}
               </button>
             </form>

--- a/src/app/pages/auth/signup/signup.component.html
+++ b/src/app/pages/auth/signup/signup.component.html
@@ -7,6 +7,14 @@
             <h1 class="h4 mb-3 heading-cta">
               Create your <span class="text-gradient-1">account</span>
             </h1>
+
+            <div *ngIf="successMessage" class="alert alert-success" role="alert">
+              {{ successMessage }}
+            </div>
+            <div *ngIf="errorMessage" class="alert alert-danger" role="alert">
+              {{ errorMessage }}
+            </div>
+
             <div class="social-auth mb-3">
               <div class="social-buttons d-grid gap-2">
                 <button
@@ -26,11 +34,24 @@
               </div>
             </div>
             <div class="auth-sep text-center text-secondary small mb-3">or</div>
-            <form (ngSubmit)="onSubmit($event)" class="auth-form" novalidate>
+
+            <form #f="ngForm" (ngSubmit)="onSubmit($event, f)" class="auth-form" novalidate>
               <div class="mb-3">
                 <label class="form-label">Full name</label>
-                <input class="form-control" [(ngModel)]="model.name" name="name" required />
+                <input
+                  class="form-control"
+                  [(ngModel)]="model.name"
+                  name="name"
+                  required
+                  minlength="2"
+                  #nameCtrl="ngModel"
+                />
+                <div class="small text-danger mt-1" *ngIf="nameCtrl.invalid && nameCtrl.touched">
+                  <span *ngIf="nameCtrl.errors?.['required']">Full name is required.</span>
+                  <span *ngIf="nameCtrl.errors?.['minlength']">Enter at least 2 characters.</span>
+                </div>
               </div>
+
               <div class="mb-3">
                 <label class="form-label">Email</label>
                 <input
@@ -39,8 +60,15 @@
                   [(ngModel)]="model.email"
                   name="email"
                   required
+                  email
+                  #emailCtrl="ngModel"
                 />
+                <div class="small text-danger mt-1" *ngIf="emailCtrl.invalid && emailCtrl.touched">
+                  <span *ngIf="emailCtrl.errors?.['required']">Email is required.</span>
+                  <span *ngIf="emailCtrl.errors?.['email']">Enter a valid email address.</span>
+                </div>
               </div>
+
               <div class="mb-3">
                 <label class="form-label">Password</label>
                 <input
@@ -49,12 +77,20 @@
                   [(ngModel)]="model.password"
                   name="password"
                   required
+                  minlength="6"
+                  #passCtrl="ngModel"
                 />
+                <div class="small text-danger mt-1" *ngIf="passCtrl.invalid && passCtrl.touched">
+                  <span *ngIf="passCtrl.errors?.['required']">Password is required.</span>
+                  <span *ngIf="passCtrl.errors?.['minlength']">Minimum 6 characters.</span>
+                </div>
               </div>
-              <button class="btn btn-join btn-lg w-100" type="submit" (click)="onSubmit($event)">
-                Sign up
+
+              <button class="btn btn-join btn-lg w-100" type="submit" [disabled]="f.invalid || submitting">
+                {{ submitting ? 'Signing up...' : 'Sign up' }}
               </button>
             </form>
+
             <div class="text-center small mt-3 text-secondary">
               Already have an account?
               <a routerLink="/login" class="text-decoration-none">Login</a>

--- a/src/app/pages/auth/signup/signup.component.ts
+++ b/src/app/pages/auth/signup/signup.component.ts
@@ -47,10 +47,16 @@ export class SignupComponent {
 
     this.accounts.registerIndividual(payload).subscribe({
       next: (res: any) => {
-        this.successMessage =
-          (res && (res.message || res.status_message)) || 'Registration successful. Please login.';
-        this.submitting = false;
-        setTimeout(() => this.router.navigate(['/login']), 1000);
+        const code = typeof res?.status_code === 'number' ? res.status_code : 200;
+        if (code === 200) {
+          this.successMessage =
+            (res && (res.message || res.status_message)) || 'Registration successful. Please login.';
+          this.submitting = false;
+          setTimeout(() => this.router.navigate(['/login']), 1000);
+        } else {
+          this.errorMessage = res?.message || res?.status_message || 'Registration failed';
+          this.submitting = false;
+        }
       },
       error: (err) => {
         const parsed = this.api.extractError(err);

--- a/src/app/pages/auth/signup/signup.component.ts
+++ b/src/app/pages/auth/signup/signup.component.ts
@@ -46,15 +46,18 @@ export class SignupComponent {
     };
 
     this.accounts.registerIndividual(payload).subscribe({
-      next: (res: any) => {
-        const code = typeof res?.status_code === 'number' ? res.status_code : 200;
-        if (code === 200) {
+      next: (res: { body: any; status: number }) => {
+        const httpOk = res?.status === 200;
+        const code = typeof res?.body?.status_code === 'number' ? res.body.status_code : 200;
+        if (httpOk && code === 200) {
           this.successMessage =
-            (res && (res.message || res.status_message)) || 'Registration successful. Please login.';
+            (res.body && (res.body.message || res.body.status_message)) ||
+            'Registration successful. Please login.';
           this.submitting = false;
           setTimeout(() => this.router.navigate(['/login']), 1000);
         } else {
-          this.errorMessage = res?.message || res?.status_message || 'Registration failed';
+          this.errorMessage =
+            res?.body?.message || res?.body?.status_message || 'Registration failed';
           this.submitting = false;
         }
       },

--- a/src/app/pages/auth/signup/signup.component.ts
+++ b/src/app/pages/auth/signup/signup.component.ts
@@ -24,7 +24,7 @@ export class SignupComponent {
   errorMessage = '';
 
   private markAllAsTouched(form: NgForm) {
-    Object.values(form.controls).forEach((c) => c.control.markAsTouched());
+    Object.values(form.controls).forEach((c: any) => c.markAsTouched());
   }
 
   onSubmit(e: Event, form?: NgForm) {

--- a/src/app/pages/auth/signup/signup.component.ts
+++ b/src/app/pages/auth/signup/signup.component.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 import { inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, NgForm } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { AccountService } from '../../../services/account.service';
+import { ApiService } from '../../../services/api.service';
 
 @Component({
   selector: 'app-signup',
@@ -15,20 +16,47 @@ import { AccountService } from '../../../services/account.service';
 export class SignupComponent {
   private readonly accounts = inject(AccountService);
   private readonly router = inject(Router);
+  private readonly api = inject(ApiService);
 
   model = { name: '', email: '', password: '' };
+  submitting = false;
+  successMessage = '';
+  errorMessage = '';
 
-  onSubmit(e: Event) {
+  private markAllAsTouched(form: NgForm) {
+    Object.values(form.controls).forEach((c) => c.control.markAsTouched());
+  }
+
+  onSubmit(e: Event, form?: NgForm) {
     e.preventDefault();
-    console.log(e);
+    if (!form) return;
+    if (form.invalid) {
+      this.markAllAsTouched(form);
+      return;
+    }
+
+    this.errorMessage = '';
+    this.successMessage = '';
+    this.submitting = true;
+
     const payload = {
       fullName: this.model.name,
       email: this.model.email,
-      phone: this.model.password,
+      phone: this.model.password, // API expects `password` in body; AccountService maps from `phone`
     };
+
     this.accounts.registerIndividual(payload).subscribe({
-      next: () => this.router.navigate(['/login']),
-      error: () => this.router.navigate(['/login']),
+      next: (res: any) => {
+        this.successMessage =
+          (res && (res.message || res.status_message)) || 'Registration successful. Please login.';
+        this.submitting = false;
+        setTimeout(() => this.router.navigate(['/login']), 1000);
+      },
+      error: (err) => {
+        const parsed = this.api.extractError(err);
+        this.errorMessage = parsed.message || 'Registration failed';
+        this.submitting = false;
+      },
     });
   }
 }

--- a/src/app/pages/landing/landing.component.ts
+++ b/src/app/pages/landing/landing.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, OnInit, ChangeDetectorRef } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, DOCUMENT } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { HttpClient } from '@angular/common/http';
@@ -48,9 +48,17 @@ interface BlogItem {
   styleUrl: './landing.component.css',
 })
 export class LandingComponent implements OnInit {
-  constructor() {}
+  private readonly http = inject(HttpClient);
+  private readonly router = inject(Router);
+  private readonly api = inject(ApiService);
+  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly doc = inject(DOCUMENT);
+
+  readonly year = new Date().getFullYear();
 
   ngOnInit(): void {
+    this.updateCanonical();
+
     this.api.getCategories().subscribe({
       next: (res) => {
         this.apiSuperCategories = (res && (res as any).data) || [];
@@ -76,17 +84,6 @@ export class LandingComponent implements OnInit {
     });
   }
 
-  private readonly http = inject(HttpClient);
-  private readonly router = inject(Router);
-  private readonly api = inject(ApiService);
-  private readonly cdr = inject(ChangeDetectorRef);
-
-  readonly year = new Date().getFullYear();
-
-  constructor() {
-    this.updateCanonical();
-  }
-
   private getOrigin(): string {
     return (globalThis as any).location?.origin || '';
   }
@@ -100,7 +97,7 @@ export class LandingComponent implements OnInit {
       link.setAttribute('rel', 'canonical');
       this.doc.head.appendChild(link);
     }
-    link.setAttribute('href', href);
+    if (link) link.setAttribute('href', href);
   }
 
   slugify(input: string): string {
@@ -176,7 +173,7 @@ export class LandingComponent implements OnInit {
       title: 'Computer & Server AMC Service',
       type: 'B2B',
       location: 'Bengaluru, India',
-      price: '���1,999 / month',
+      price: '₹1,999 / month',
       cover:
         'https://images.unsplash.com/photo-1517336714731-489689fd1ca8?q=80&w=1200&auto=format&fit=crop',
     },
@@ -326,7 +323,7 @@ export class LandingComponent implements OnInit {
     });
     const url = `https://nominatim.openstreetmap.org/search?${params.toString()}`;
     this.http.get<any[]>(url).subscribe({
-      next: (res) => {
+      next: (res: any[]) => {
         const allowed = new Set([
           'city',
           'town',
@@ -338,9 +335,9 @@ export class LandingComponent implements OnInit {
           'locality',
         ]);
         const onlyIn = (res || []).filter(
-          (r) => (r.address?.country_code || '').toLowerCase() === 'in',
+          (r: any) => (r.address?.country_code || '').toLowerCase() === 'in',
         );
-        const cleaned = (onlyIn.length ? onlyIn : res || []).filter((r) =>
+        const cleaned = (onlyIn.length ? onlyIn : res || []).filter((r: any) =>
           allowed.has((r.type || '').toLowerCase()),
         );
         this.locationResults = cleaned.slice(0, 8);

--- a/src/app/pages/listings/listings.component.html
+++ b/src/app/pages/listings/listings.component.html
@@ -96,7 +96,7 @@
                 ></i
                 >{{ sc.title }}</span
               >
-              <span class="badge bg-light text-dark">{{ sc.categories?.length || 0 }}</span>
+              <span class="badge bg-light text-dark">{{ sc.categories.length || 0 }}</span>
             </button>
             <div class="sub-list ms-3" *ngIf="expandedSuperIds.has(sc.id)">
               <div class="form-check" *ngFor="let c of sc.categories">

--- a/src/app/pages/provider/register/provider-register.component.html
+++ b/src/app/pages/provider/register/provider-register.component.html
@@ -212,7 +212,7 @@
                         ></i
                         >{{ sc.title }}</span
                       >
-                      <span class="badge bg-light text-dark">{{ sc.categories?.length || 0 }}</span>
+                      <span class="badge bg-light text-dark">{{ sc.categories.length || 0 }}</span>
                     </button>
                     <div class="sub-list ms-3" *ngIf="expandedSuperIds.has(sc.id)">
                       <div class="form-check" *ngFor="let c of sc.categories">

--- a/src/app/services/account.service.ts
+++ b/src/app/services/account.service.ts
@@ -102,7 +102,7 @@ export class AccountService {
           this.setAccount(acc);
         }
       }),
-      map((resp) => resp.body as any),
+      map((resp) => ({ body: resp.body as any, status: resp.status })),
     );
   }
 

--- a/src/app/services/account.service.ts
+++ b/src/app/services/account.service.ts
@@ -85,18 +85,24 @@ export class AccountService {
     };
 
     const url = `${this.resolveBase()}/api/User/register`;
-    return this.http.post(url, body).pipe(
-      tap(() => {
-        const acc: IndividualAccount = {
-          id: 1,
-          type: 'Individual',
-          fullName: data.fullName,
-          email: data.email,
-          phone: data.phone,
-          createdAt: new Date().toISOString(),
-        };
-        this.setAccount(acc);
+    return this.http.post(url, body, { observe: 'response' as const }).pipe(
+      tap((resp) => {
+        const statusOk = resp.status === 200;
+        const b: any = resp.body;
+        const codeOk = typeof b?.status_code === 'number' ? b.status_code === 200 : true;
+        if (statusOk && codeOk) {
+          const acc: IndividualAccount = {
+            id: 1,
+            type: 'Individual',
+            fullName: data.fullName,
+            email: data.email,
+            phone: data.phone,
+            createdAt: new Date().toISOString(),
+          };
+          this.setAccount(acc);
+        }
       }),
+      map((resp) => resp.body as any),
     );
   }
 

--- a/src/app/services/account.service.ts
+++ b/src/app/services/account.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { tap } from 'rxjs/operators';
+import { tap, map } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
 
 import {

--- a/src/app/services/account.service.ts
+++ b/src/app/services/account.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@angular/core';
 import { inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { tap } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+
 import {
   ProviderAccount,
   CompanyAccount,
@@ -17,6 +19,18 @@ export class AccountService {
   private mem: string | null = null; // SSR-safe fallback
 
   private http = inject(HttpClient);
+
+  private resolveBase(): string {
+    let base = environment.base_path || '';
+    if (
+      typeof window !== 'undefined' &&
+      window.location?.protocol === 'https:' &&
+      base.startsWith('http://')
+    ) {
+      base = 'https://' + base.substring('http://'.length);
+    }
+    return base;
+  }
 
   private get storageAvailable() {
     return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
@@ -70,7 +84,7 @@ export class AccountService {
       company: '',
     };
 
-    const url = 'api/User/register';
+    const url = `${this.resolveBase()}/api/User/register`;
     return this.http.post(url, body).pipe(
       tap(() => {
         const acc: IndividualAccount = {


### PR DESCRIPTION
## Purpose

The user requested proper validation for the signup form with success/error message handling after API calls. They wanted to show appropriate messages based on the API response status code (200 for success, otherwise error) and prevent redirection to login on errors. Additionally, they needed to resolve an Angular warning about HttpClient not being configured to use fetch APIs for better SSR performance.

## Code changes

- **HttpClient Configuration**: Added `withFetch()` to `provideHttpClient()` in both `app.config.ts` and `app.config.server.ts` to enable fetch APIs for better SSR performance
- **Signup Form Validation**: 
  - Added form validation with required fields, email format, and minimum length constraints
  - Added visual error messages that display when fields are invalid and touched
  - Added form state management with disabled submit button when form is invalid or submitting
- **API Response Handling**: 
  - Implemented proper success/error message display based on API response status codes
  - Added loading state with "Signing up..." text during submission
  - Only redirect to login on successful registration (status code 200)
  - Show error messages from API response when registration fails
- **Service Updates**: Modified `AccountService.registerIndividual()` to return response with status information for proper error handling
- **Code Cleanup**: Removed unused imports and fixed TypeScript type annotations throughout components

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 44`

🔗 [Edit in Builder.io](https://builder.io/app/projects/000ca072e81642029534f7ff199f8dcf/curry-field)

👀 [Preview Link](https://000ca072e81642029534f7ff199f8dcf-curry-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>000ca072e81642029534f7ff199f8dcf</projectId>-->
<!--<branchName>curry-field</branchName>-->