### PR TITLE
Fix build error: change outputMode from static to server

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -23,7 +23,7 @@
             ],
             "styles": ["src/styles.css"],
             "server": "src/main.server.ts",
-            "outputMode": "static",
+            "outputMode": "server",
             "ssr": {
               "entry": "src/server.ts"
             }


### PR DESCRIPTION
## Purpose
Resolve build error where route '/' was configured with server render mode but the build 'outputMode' was set to 'static', causing a configuration mismatch that prevented successful builds.

## Code changes
- Updated `angular.json` configuration
- Changed `outputMode` from "static" to "server" to align with the server render mode requirements
- This ensures compatibility between the routing configuration and build output mode

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 45`

🔗 [Edit in Builder.io](https://builder.io/app/projects/000ca072e81642029534f7ff199f8dcf/pixel-hub)

👀 [Preview Link](https://000ca072e81642029534f7ff199f8dcf-pixel-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>000ca072e81642029534f7ff199f8dcf</projectId>-->
<!--<branchName>pixel-hub</branchName>-->