### PR TITLE
Fix: Trigger change detection after filter updates

### DIFF
--- a/src/app/pages/listings/desktop-listings.component.ts
+++ b/src/app/pages/listings/desktop-listings.component.ts
@@ -197,9 +197,7 @@ export class DesktopListingsComponent implements OnInit {
   toggleSubCategory(name: string) {
     const idx = this.filters.selectedCategories.indexOf(name);
     if (idx >= 0) {
-      this.filters.selectedCategories = this.filters.selectedCategories.filter(
-        (_, i) => i !== idx,
-      );
+      this.filters.selectedCategories = this.filters.selectedCategories.filter((_, i) => i !== idx);
     } else {
       this.filters.selectedCategories = [...this.filters.selectedCategories, name];
     }

--- a/src/app/pages/listings/desktop-listings.component.ts
+++ b/src/app/pages/listings/desktop-listings.component.ts
@@ -210,6 +210,7 @@ export class DesktopListingsComponent implements OnInit {
   clearSelectedCategories() {
     this.filters.selectedCategories = [];
     this.setPage(1);
+    this.cd.detectChanges();
   }
 
   private serviceTypeMap: Record<string, string[]> = {};

--- a/src/app/pages/listings/desktop-listings.component.ts
+++ b/src/app/pages/listings/desktop-listings.component.ts
@@ -196,9 +196,15 @@ export class DesktopListingsComponent implements OnInit {
 
   toggleSubCategory(name: string) {
     const idx = this.filters.selectedCategories.indexOf(name);
-    if (idx >= 0) this.filters.selectedCategories.splice(idx, 1);
-    else this.filters.selectedCategories.push(name);
+    if (idx >= 0) {
+      this.filters.selectedCategories = this.filters.selectedCategories.filter(
+        (_, i) => i !== idx,
+      );
+    } else {
+      this.filters.selectedCategories = [...this.filters.selectedCategories, name];
+    }
     this.setPage(1);
+    this.cd.detectChanges();
   }
 
   clearSelectedCategories() {

--- a/src/app/pages/listings/desktop-listings.component.ts
+++ b/src/app/pages/listings/desktop-listings.component.ts
@@ -419,6 +419,7 @@ export class DesktopListingsComponent implements OnInit {
     this.filters.location = item.display_name;
     this.locationResults = [];
     this.setPage(1);
+    this.cd.detectChanges();
   }
 
   private queryPhoton(q: string) {

--- a/src/app/pages/listings/desktop-listings.component.ts
+++ b/src/app/pages/listings/desktop-listings.component.ts
@@ -389,6 +389,7 @@ export class DesktopListingsComponent implements OnInit {
     if (typeof window !== 'undefined')
       window.localStorage.setItem(this.cityPrefKey, this.filters.location);
     this.setPage(1);
+    this.cd.detectChanges();
   }
 
   chooseCity(name: string) {

--- a/src/app/pages/listings/mobile-listings.component.ts
+++ b/src/app/pages/listings/mobile-listings.component.ts
@@ -193,9 +193,15 @@ export class MobileListingsComponent implements OnInit {
 
   toggleSubCategory(name: string) {
     const idx = this.filters.selectedCategories.indexOf(name);
-    if (idx >= 0) this.filters.selectedCategories.splice(idx, 1);
-    else this.filters.selectedCategories.push(name);
+    if (idx >= 0) {
+      this.filters.selectedCategories = this.filters.selectedCategories.filter(
+        (_, i) => i !== idx,
+      );
+    } else {
+      this.filters.selectedCategories = [...this.filters.selectedCategories, name];
+    }
     this.setPage(1);
+    this.cd.detectChanges();
   }
 
   clearSelectedCategories() {

--- a/src/app/pages/listings/mobile-listings.component.ts
+++ b/src/app/pages/listings/mobile-listings.component.ts
@@ -350,6 +350,7 @@ export class MobileListingsComponent implements OnInit {
 
   applyFilters() {
     this.setPage(1);
+    this.cd.detectChanges();
     this.closeFilterSheet();
   }
 

--- a/src/app/pages/listings/mobile-listings.component.ts
+++ b/src/app/pages/listings/mobile-listings.component.ts
@@ -313,6 +313,7 @@ export class MobileListingsComponent implements OnInit {
     this.filters.location = item.display_name;
     this.locationResults = [];
     this.setPage(1);
+    this.cd.detectChanges();
   }
 
   private queryPhoton(q: string) {

--- a/src/app/pages/listings/mobile-listings.component.ts
+++ b/src/app/pages/listings/mobile-listings.component.ts
@@ -194,9 +194,7 @@ export class MobileListingsComponent implements OnInit {
   toggleSubCategory(name: string) {
     const idx = this.filters.selectedCategories.indexOf(name);
     if (idx >= 0) {
-      this.filters.selectedCategories = this.filters.selectedCategories.filter(
-        (_, i) => i !== idx,
-      );
+      this.filters.selectedCategories = this.filters.selectedCategories.filter((_, i) => i !== idx);
     } else {
       this.filters.selectedCategories = [...this.filters.selectedCategories, name];
     }

--- a/src/app/pages/listings/mobile-listings.component.ts
+++ b/src/app/pages/listings/mobile-listings.component.ts
@@ -284,6 +284,7 @@ export class MobileListingsComponent implements OnInit {
     if (typeof window !== 'undefined')
       window.localStorage.setItem(this.cityPrefKey, this.filters.location);
     this.setPage(1);
+    this.cd.detectChanges();
   }
 
   chooseCity(name: string) {

--- a/src/app/pages/listings/mobile-listings.component.ts
+++ b/src/app/pages/listings/mobile-listings.component.ts
@@ -207,6 +207,7 @@ export class MobileListingsComponent implements OnInit {
   clearSelectedCategories() {
     this.filters.selectedCategories = [];
     this.setPage(1);
+    this.cd.detectChanges();
   }
 
   private cityCoords: Record<string, { lat: number; lon: number }> = {


### PR DESCRIPTION
### Purpose

The user observed that the item list was not updating correctly after applying filters, particularly in the mobile view. The goal is to fix this bug so that the list refreshes reliably whenever filters are changed.

### Code changes

- **Manual Change Detection:** To ensure the UI updates promptly, `this.cd.detectChanges()` has been added to methods that modify filter criteria in both `desktop-listings.component.ts` and `mobile-listings.component.ts`. This includes `toggleSubCategory`, `clearSelectedCategories`, `setLocation`, `chooseLocation`, and `applyFilters`.
- **State Immutability:** The `toggleSubCategory` method was updated to handle the `selectedCategories` array in an immutable way by using `filter` and spread syntax instead of `splice`. This helps prevent unexpected behavior with Angular's change detection.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/09e255cf212b438bb8eff0c25e75e9ee/flare-hub)

👀 [Preview Link](https://09e255cf212b438bb8eff0c25e75e9ee-flare-hub.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 105`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>09e255cf212b438bb8eff0c25e75e9ee</projectId>-->
<!--<branchName>flare-hub</branchName>-->