### PR TITLE
Fix: Mobile UI issues and location search

### DIFF
--- a/src/app/pages/category-selection/category-selection-page.component.css
+++ b/src/app/pages/category-selection/category-selection-page.component.css
@@ -63,7 +63,7 @@
   background: #fff;
   border: 1px solid #e7e9f3;
   border-radius: 12px;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .category-page-card-header {

--- a/src/app/pages/category-selection/category-selection-page.component.html
+++ b/src/app/pages/category-selection/category-selection-page.component.html
@@ -87,7 +87,7 @@
   </div>
 
   <!-- Category Card -->
-  <div class="category-page-card" *ngIf="supercategory">
+  <div class="category-page-card" *ngIf="supercategory && !preSelectedCategoryName">
     <div class="category-page-card-header">
       <i class="bi bi-grid card-icon"></i>
       <h2 class="category-page-card-title">What exact service do you need?</h2>

--- a/src/app/pages/category-selection/category-selection-page.component.html
+++ b/src/app/pages/category-selection/category-selection-page.component.html
@@ -8,8 +8,12 @@
       <i class="me-2" [ngClass]="iconClass(supercategory.icon)"></i>
       {{ supercategory.title }}
     </h1>
-    <p class="category-page-subtitle" *ngIf="!preSelectedCategoryName">Complete the information to find services</p>
-    <p class="category-page-subtitle" *ngIf="preSelectedCategoryName">Enter your location to find services</p>
+    <p class="category-page-subtitle" *ngIf="!preSelectedCategoryName">
+      Complete the information to find services
+    </p>
+    <p class="category-page-subtitle" *ngIf="preSelectedCategoryName">
+      Enter your location to find services
+    </p>
   </div>
 </div>
 

--- a/src/app/pages/category-selection/category-selection-page.component.html
+++ b/src/app/pages/category-selection/category-selection-page.component.html
@@ -8,7 +8,8 @@
       <i class="me-2" [ngClass]="iconClass(supercategory.icon)"></i>
       {{ supercategory.title }}
     </h1>
-    <p class="category-page-subtitle">Complete the information to find services</p>
+    <p class="category-page-subtitle" *ngIf="!preSelectedCategoryName">Complete the information to find services</p>
+    <p class="category-page-subtitle" *ngIf="preSelectedCategoryName">Enter your location to find services</p>
   </div>
 </div>
 

--- a/src/app/pages/category-selection/category-selection-page.component.ts
+++ b/src/app/pages/category-selection/category-selection-page.component.ts
@@ -27,6 +27,7 @@ export class CategorySelectionPageComponent implements OnInit {
 
   supercategory: ApiSuperCategory | null = null;
   supercategoryId: number | null = null;
+  preSelectedCategoryName: string | null = null;
 
   // Location search
   locationInput = '';

--- a/src/app/pages/category-selection/category-selection-page.component.ts
+++ b/src/app/pages/category-selection/category-selection-page.component.ts
@@ -43,12 +43,14 @@ export class CategorySelectionPageComponent implements OnInit {
 
   ngOnInit(): void {
     const id = this.route.snapshot.queryParamMap.get('supercategoryId');
+    const categoryName = this.route.snapshot.queryParamMap.get('category');
     if (!id) {
       this.router.navigate(['/']);
       return;
     }
 
     this.supercategoryId = parseInt(id, 10);
+    this.preSelectedCategoryName = categoryName;
     this.api.getCategories().subscribe({
       next: (res) => {
         const categories = (res as any).data || [];
@@ -56,6 +58,13 @@ export class CategorySelectionPageComponent implements OnInit {
           categories.find((c: ApiSuperCategory) => c.id === this.supercategoryId) || null;
         if (!this.supercategory) {
           this.router.navigate(['/']);
+        } else if (this.preSelectedCategoryName && this.supercategory.categories) {
+          const preSelected = this.supercategory.categories.find(
+            (c) => c.name === this.preSelectedCategoryName,
+          );
+          if (preSelected) {
+            this.selectedCategory = preSelected;
+          }
         }
         this.cdr.detectChanges();
       },

--- a/src/app/pages/landing/desktop-landing.component.html
+++ b/src/app/pages/landing/desktop-landing.component.html
@@ -156,10 +156,12 @@
               </div>
               <div class="row g-3 supercat-grid px-2 pb-2">
                 <div class="col-6 col-md-3 col-lg-2" *ngFor="let c of sc.items">
-                  <a
-                    class="text-decoration-none text-dark"
-                    [routerLink]="'/listings'"
-                    [queryParams]="{ category: c.name }"
+                  <button
+                    type="button"
+                    class="text-decoration-none text-dark w-100"
+                    style="background: none; border: none; padding: 0; cursor: pointer;"
+                    (click)="openCategorySelection(apiSuperCategoryFromVisibleData(sc.key))"
+                    [attr.aria-label]="'Select ' + c.name + ' category'"
                   >
                     <div class="category-card p-3 text-center h-100">
                       <span class="category-icon mb-2">
@@ -173,7 +175,7 @@
                       <div class="fw-semibold">{{ c.name }}</div>
                       <small class="text-secondary">{{ c.count }} listings</small>
                     </div>
-                  </a>
+                  </button>
                 </div>
               </div>
             </div>

--- a/src/app/pages/landing/desktop-landing.component.html
+++ b/src/app/pages/landing/desktop-landing.component.html
@@ -152,7 +152,14 @@
             <div class="supercat-section mb-3" [ngClass]="sc.colorClass">
               <div class="d-flex align-items-center justify-content-between mb-2 px-2 pt-2">
                 <h3 class="h6 mb-0">{{ sc.title }}</h3>
-                <a class="small text-decoration-none" [routerLink]="'/listings'">View all</a>
+                <button
+                  type="button"
+                  class="small text-decoration-none"
+                  style="background: none; border: none; padding: 0; cursor: pointer; color: inherit;"
+                  (click)="openCategorySelection(apiSuperCategoryFromVisibleData(sc.key))"
+                >
+                  View all
+                </button>
               </div>
               <div class="row g-3 supercat-grid px-2 pb-2">
                 <div class="col-6 col-md-3 col-lg-2" *ngFor="let c of sc.items">

--- a/src/app/pages/landing/desktop-landing.component.html
+++ b/src/app/pages/landing/desktop-landing.component.html
@@ -167,7 +167,7 @@
                     type="button"
                     class="text-decoration-none text-dark w-100"
                     style="background: none; border: none; padding: 0; cursor: pointer;"
-                    (click)="openCategorySelection(apiSuperCategoryFromVisibleData(sc.key))"
+                    (click)="openCategorySelection(apiSuperCategoryFromVisibleData(sc.key), c.name)"
                     [attr.aria-label]="'Select ' + c.name + ' category'"
                   >
                     <div class="category-card p-3 text-center h-100">

--- a/src/app/pages/landing/desktop-landing.component.html
+++ b/src/app/pages/landing/desktop-landing.component.html
@@ -155,7 +155,13 @@
                 <button
                   type="button"
                   class="small text-decoration-none"
-                  style="background: none; border: none; padding: 0; cursor: pointer; color: inherit;"
+                  style="
+                    background: none;
+                    border: none;
+                    padding: 0;
+                    cursor: pointer;
+                    color: inherit;
+                  "
                   (click)="openCategorySelection(apiSuperCategoryFromVisibleData(sc.key))"
                 >
                   View all
@@ -166,7 +172,7 @@
                   <button
                     type="button"
                     class="text-decoration-none text-dark w-100"
-                    style="background: none; border: none; padding: 0; cursor: pointer;"
+                    style="background: none; border: none; padding: 0; cursor: pointer"
                     (click)="openCategorySelection(apiSuperCategoryFromVisibleData(sc.key), c.name)"
                     [attr.aria-label]="'Select ' + c.name + ' category'"
                   >

--- a/src/app/pages/landing/desktop-landing.component.ts
+++ b/src/app/pages/landing/desktop-landing.component.ts
@@ -350,4 +350,15 @@ export class DesktopLandingComponent implements OnInit {
     if (icon.startsWith('bi-')) return ['bi', icon];
     return [icon];
   }
+
+  apiSuperCategoryFromVisibleData(key: string | number): ApiSuperCategory | null {
+    return this.apiSuperCategories.find((s) => String(s.id) === String(key)) || null;
+  }
+
+  openCategorySelection(supercategory: ApiSuperCategory | null): void {
+    if (!supercategory) return;
+    this.router.navigate(['/category-selection'], {
+      queryParams: { supercategoryId: supercategory.id },
+    });
+  }
 }

--- a/src/app/pages/landing/desktop-landing.component.ts
+++ b/src/app/pages/landing/desktop-landing.component.ts
@@ -355,10 +355,12 @@ export class DesktopLandingComponent implements OnInit {
     return this.apiSuperCategories.find((s) => String(s.id) === String(key)) || null;
   }
 
-  openCategorySelection(supercategory: ApiSuperCategory | null): void {
+  openCategorySelection(supercategory: ApiSuperCategory | null, categoryName?: string): void {
     if (!supercategory) return;
-    this.router.navigate(['/category-selection'], {
-      queryParams: { supercategoryId: supercategory.id },
-    });
+    const params: any = { supercategoryId: supercategory.id };
+    if (categoryName) {
+      params.category = categoryName;
+    }
+    this.router.navigate(['/category-selection'], { queryParams: params });
   }
 }

--- a/src/app/pages/listings/desktop-listings.component.ts
+++ b/src/app/pages/listings/desktop-listings.component.ts
@@ -119,13 +119,15 @@ export class DesktopListingsComponent implements OnInit {
     this.isLoadingListings = true;
     const superCategory = this.route.snapshot.queryParamMap.get('super') || undefined;
     const category = this.route.snapshot.queryParamMap.get('category') || undefined;
-    const location = this.route.snapshot.queryParamMap.get('location') || undefined;
+    const lat = this.route.snapshot.queryParamMap.get('lat');
+    const lon = this.route.snapshot.queryParamMap.get('lon');
 
     this.api
       .getListings(this.apiPage, this.apiPerPage, {
         superCategory,
         category,
-        location,
+        lat: lat ? parseFloat(lat) : undefined,
+        lon: lon ? parseFloat(lon) : undefined,
       })
       .subscribe({
         next: (res) => {

--- a/src/app/pages/listings/mobile-listings.component.ts
+++ b/src/app/pages/listings/mobile-listings.component.ts
@@ -116,13 +116,15 @@ export class MobileListingsComponent implements OnInit {
     this.isLoadingListings = true;
     const superCategory = this.route.snapshot.queryParamMap.get('super') || undefined;
     const category = this.route.snapshot.queryParamMap.get('category') || undefined;
-    const location = this.route.snapshot.queryParamMap.get('location') || undefined;
+    const lat = this.route.snapshot.queryParamMap.get('lat');
+    const lon = this.route.snapshot.queryParamMap.get('lon');
 
     this.api
       .getListings(this.apiPage, this.apiPerPage, {
         superCategory,
         category,
-        location,
+        lat: lat ? parseFloat(lat) : undefined,
+        lon: lon ? parseFloat(lon) : undefined,
       })
       .subscribe({
         next: (res) => {

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -108,7 +108,8 @@ export class ApiService {
     options?: {
       superCategory?: string;
       category?: string;
-      location?: string;
+      lat?: number;
+      lon?: number;
     },
   ): Observable<ApiListingResponse> {
     let url = `${this.resolveBase()}/api/Listing?page=${page}&perPage=${perPage}`;
@@ -118,8 +119,8 @@ export class ApiService {
     if (options?.category) {
       url += `&category=${encodeURIComponent(options.category)}`;
     }
-    if (options?.location) {
-      url += `&location=${encodeURIComponent(options.location)}`;
+    if (options?.lat !== undefined && options?.lon !== undefined) {
+      url += `&lat=${options.lat}&lon=${options.lon}`;
     }
     return this.http.get<ApiListingResponse>(url);
   }


### PR DESCRIPTION
### Purpose
Based on the conversation, the goal was to fix several bugs and improve user experience. This included resolving a visual glitch on mobile where autocomplete suggestions were hidden, ensuring the correct location format (latitude and longitude) is used for searches, and refining the category selection flow to allow pre-selecting a subcategory.

### Code changes

*   **API Service & Listings**:
    *   Modified `api.service.ts` to accept latitude and longitude (`lat`, `lon`) instead of a location string for the `getListings` endpoint.
    *   Updated `desktop-listings.component.ts` and `mobile-listings.component.ts` to pass `lat` and `lon` to the API call.

*   **Category Selection Flow**:
    *   In `desktop-landing.component.ts`, implemented the `openCategorySelection` function to navigate users to the category selection page with the supercategory and chosen subcategory pre-selected.
    *   Updated `category-selection-page.component.ts` to handle the pre-selected category from the URL parameters.
    *   Adjusted `category-selection-page.component.html` to conditionally display UI elements based on whether a category is pre-selected.

*   **Mobile UI Fix**:
    *   In `category-selection-page.component.css`, changed `overflow: hidden` to `overflow: visible` on the `.category-page-card` to fix the z-index issue where location suggestions were being cut off.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/7f009f6afda84e169058cecbb4f49c0d/quantum-lab)

👀 [Preview Link](https://7f009f6afda84e169058cecbb4f49c0d-quantum-lab.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 108`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7f009f6afda84e169058cecbb4f49c0d</projectId>-->
<!--<branchName>quantum-lab</branchName>-->